### PR TITLE
Adding MQTT exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAGS = influxdb postgres gcp aws
+TAGS = influxdb postgres gcp aws mqtt
 
 .PHONY: all build install
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ http:
 mqtt:
   enabled: true
   addr: "ssl://localhost:8883" # tcp://localhost:1883 for non-TLS connections
-  clinet_id: ruuvitag-gollector
+  client_id: ruuvitag-gollector
   username: mqtt_user
   password: my_secret_password
   ca_file: root_ca.pem

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The following exporters are supported for sending measurements:
 - AWS DynamoDB
 - AWS SQS
 - GCP Pub/Sub
+- MQTT
 
 See the command-line help for the arguments needed by each exporter:
 
@@ -109,4 +110,14 @@ http:
   enabled: true
   url: https://my-api.herokuapp.com/receive
   token: MyHerokuToken
+  
+mqtt:
+  enabled: true
+  addr: "ssl://localhost:8883" # tcp://localhost:1883 for non-TLS connections
+  clinet_id: ruuvitag-gollector
+  username: mqtt_user
+  password: my_secret_password
+  ca_file: root_ca.pem
+  auto_reconnect: true
+  reconnect_interval: 30
 ```

--- a/cmd/mqtt.go
+++ b/cmd/mqtt.go
@@ -38,7 +38,7 @@ func addMQTTExporter(exporters *[]exporter.Exporter) error {
 		ReconnectInterval: time.Duration(viper.GetInt("mqtt.reconnect_interval")) * time.Second,
 	})
 	if err != nil {
-		return nil
+		return err
 	}
 	*exporters = append(*exporters, exporter)
 	return nil

--- a/cmd/mqtt.go
+++ b/cmd/mqtt.go
@@ -1,0 +1,45 @@
+// +build mqtt
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/niktheblak/ruuvitag-gollector/pkg/exporter"
+	"github.com/niktheblak/ruuvitag-gollector/pkg/exporter/mqtt"
+)
+
+func init() {
+	rootCmd.PersistentFlags().Bool("mqtt.enabled", false, "Publish measurements to a MQTT broker")
+	rootCmd.PersistentFlags().String("mqtt.addr", "tcp://localhost:1883", "MQTT broker address with protocol (tcp or ssl), host and port")
+	rootCmd.PersistentFlags().String("mqtt.client_id", "ruuvitag-gollector", "MQTT client id")
+	rootCmd.PersistentFlags().String("mqtt.username", "", "MQTT username")
+	rootCmd.PersistentFlags().String("mqtt.password", "", "MQTT password")
+	rootCmd.PersistentFlags().String("mqtt.ca_file", "", "Path to a CA file, if TLS used")
+	rootCmd.PersistentFlags().Bool("mqtt.auto_reconnect", false, "Enable auto reconnection if connection is lost")
+	rootCmd.PersistentFlags().Int("mqtt.reconnect_interval", 60, "Sets the maximum time in seconds that will be waited between reconnection attempts")
+}
+
+func addMQTTExporter(exporters *[]exporter.Exporter) error {
+	addr := viper.GetString("mqtt.addr")
+	if addr == "" {
+		return fmt.Errorf("MQTT broker address must be specified")
+	}
+	exporter, err := mqtt.New(mqtt.Config{
+		Addr:              addr,
+		ClientId:          viper.GetString("mqtt.client_id"),
+		Username:          viper.GetString("mqtt.username"),
+		Password:          viper.GetString("mqtt.password"),
+		CaFile:            viper.GetString("mqtt.ca_file"),
+		AutoReconnect:     viper.GetBool("mqtt.auto_reconnect"),
+		ReconnectInterval: time.Duration(viper.GetInt("mqtt.reconnect_interval")) * time.Second,
+	})
+	if err != nil {
+		return nil
+	}
+	*exporters = append(*exporters, exporter)
+	return nil
+}

--- a/cmd/mqtt_dummy.go
+++ b/cmd/mqtt_dummy.go
@@ -1,0 +1,9 @@
+// +build !mqtt
+
+package cmd
+
+import "github.com/niktheblak/ruuvitag-gollector/pkg/exporter"
+
+func addMQTTExporter(exporters *[]exporter.Exporter) error {
+	return ErrNotEnabled
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,6 +173,11 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 		exporters = append(exporters, exp)
 	}
+	if viper.GetBool("mqtt.enabled") {
+		if err := addMQTTExporter(&exporters); err != nil {
+			return fmt.Errorf("failed to create MQTT exporter: %w", err)
+		}
+	}
 	device = viper.GetString("device")
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/logging v1.1.1 // indirect
 	cloud.google.com/go/pubsub v1.8.1
 	github.com/aws/aws-sdk-go v1.35.11
+	github.com/eclipse/paho.mqtt.golang v1.3.2
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-ble/ble v0.0.0-20200407180624-067514cd6e24
 	github.com/influxdata/influxdb-client-go/v2 v2.2.2

--- a/pkg/exporter/mqtt/config.go
+++ b/pkg/exporter/mqtt/config.go
@@ -1,0 +1,15 @@
+package mqtt
+
+import (
+	"time"
+)
+
+type Config struct {
+	Addr              string
+	ClientId          string
+	Username          string
+	Password          string
+	CaFile            string
+	AutoReconnect     bool
+	ReconnectInterval time.Duration
+}

--- a/pkg/exporter/mqtt/mqtt.go
+++ b/pkg/exporter/mqtt/mqtt.go
@@ -1,0 +1,88 @@
+// +build mqtt
+
+package mqtt
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"io/ioutil"
+	"strings"
+
+	"github.com/niktheblak/ruuvitag-gollector/pkg/exporter"
+	"github.com/niktheblak/ruuvitag-gollector/pkg/sensor"
+)
+
+type mqttExporter struct {
+	client    mqtt.Client
+	tlsConfig *tls.Config
+}
+
+func New(cfg Config) (exporter.Exporter, error) {
+	opts := mqtt.NewClientOptions()
+	opts.AddBroker(cfg.Addr)
+	opts.SetClientID(cfg.ClientId)
+	if cfg.Username != "" && cfg.Password != "" {
+		opts.SetUsername(cfg.Username)
+		opts.SetPassword(cfg.Password)
+	}
+	opts.SetAutoReconnect(cfg.AutoReconnect)
+	opts.SetMaxReconnectInterval(cfg.ReconnectInterval)
+	tlsConfig, err := newTlsConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if tlsConfig != nil {
+		opts.SetTLSConfig(tlsConfig)
+	}
+	client := mqtt.NewClient(opts)
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		return nil, token.Error()
+	}
+	return &mqttExporter{
+		client:    client,
+		tlsConfig: tlsConfig,
+	}, nil
+}
+
+func newTlsConfig(cfg Config) (*tls.Config, error) {
+	if cfg.CaFile != "" {
+		certpool := x509.NewCertPool()
+		ca, err := ioutil.ReadFile(cfg.CaFile)
+		if err != nil {
+			return nil, err
+		}
+		certpool.AppendCertsFromPEM(ca)
+		return &tls.Config{
+			RootCAs: certpool,
+		}, nil
+	}
+	return nil, nil
+}
+
+func (m mqttExporter) Name() string {
+	return fmt.Sprintf("MQTT")
+}
+
+func (m mqttExporter) Export(ctx context.Context, data sensor.Data) error {
+	buf := new(bytes.Buffer)
+	enc := json.NewEncoder(buf)
+	err := enc.Encode(data)
+	if err != nil {
+		return err
+	}
+	mac := strings.Replace(data.Addr, ":", "", -1)
+	topic := fmt.Sprintf("ruuvitag-gollector/%s/%s", data.Name, mac)
+	token := m.client.Publish(topic, 0, false, buf.String())
+	token.Wait()
+	return token.Error()
+}
+
+func (m mqttExporter) Close() error {
+	m.client.Disconnect(0)
+	return nil
+}

--- a/pkg/exporter/mqtt/mqtt_dummy.go
+++ b/pkg/exporter/mqtt/mqtt_dummy.go
@@ -1,0 +1,11 @@
+// +build !mqtt
+
+package mqtt
+
+import (
+	"github.com/niktheblak/ruuvitag-gollector/pkg/exporter"
+)
+
+func New(cfg Config) exporter.Exporter {
+	return exporter.NoOp{ReportedName: "MQTT"}
+}

--- a/scripts/docker-run-mosquitto.sh
+++ b/scripts/docker-run-mosquitto.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+mosquitto_config=$(mktemp)
+echo "listener 1883
+allow_anonymous true" > $mosquitto_config
+
+docker run \
+  -it \
+  --rm \
+  --name mosquitto \
+  --network ruuvitag \
+  -p 1883:1883 \
+  -v $mosquitto_config:/mosquitto/config/mosquitto.conf\
+  eclipse-mosquitto:2.0.8
+
+rm $mosquitto_config

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAGS="influxdb postgres gcp aws"
+TAGS="influxdb postgres gcp aws mqtt"
 
 docker run \
   -it \

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAGS="influxdb postgresql gcp aws"
+TAGS="influxdb postgresql gcp aws mqtt"
 
 docker run \
   -it \


### PR DESCRIPTION
Hi,

This pull request add a MQTT exporter, which supports both TLS and non-TLS connections. The following arguments are added:
```
--mqtt.addr string               MQTT broker address with protocol (tcp or ssl), host and port (default "tcp://localhost:1883")
--mqtt.auto_reconnect            Enable auto reconnection if connection is lost
--mqtt.ca_file string            Path to a CA file, if TLS used
--mqtt.client_id string          MQTT client id (default "ruuvitag-gollector")
--mqtt.enabled                   Publish measurements to a MQTT broker
--mqtt.password string           MQTT password
--mqtt.reconnect_interval int    Sets the maximum time in seconds that will be waited between reconnection attempts (default 60)
--mqtt.username string           MQTT username
```

Minimal setup to test it
```sh
$ cat ruuvitag-gollector.yaml
interval: 0m

ruuvitags:
  "CC:CA:7E:52:CC:34": Test

mqtt:
  enabled: true
  addr: "tcp://localhost:1883"

$ ./scripts/docker-run-mosquitto.sh

$ ./ruuvitag-gollector mock
```